### PR TITLE
(readme): fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 "# cont-repo" 
 
-href="https://git.com"
+href="https://git-scm.com"
 color="red"


### PR DESCRIPTION
## What kind of changes does this PR produce?

Fixing a broken link to Git documentation.

## What is the current behaviour?

The README file has a broken link that goes to "https://git.com".

## What is the new behaviour?

The link in README file will go here now: "https://git-scm.com".